### PR TITLE
Fix build and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     implementation 'com.github.spotbugs:spotbugs:3.1.12'
     implementation 'org.danilopianini:javalib-java7:0.6.1'
     implementation 'org.apache.commons:commons-math3:3.4'
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.50' // for Protelis2KotlinDoc
 }
 
 // set gradle version when generating the wrapper
@@ -101,7 +100,8 @@ Protelis2KotlinDoc {
     // protelisVersion.set("+")
     outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
     debug.set(true) // Debug prints are disabled by default
-    automaticDependencies.set(false)
+    protelisVersion.set("10.6.0")
+    automaticDependencies.set(true)
 }
 
 findbugs {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'maven-publish'
     id 'checkstyle'
     id 'findbugs'
-    //id("org.protelis.protelisdoc") version "0.2.0"
+    id("org.protelis.protelisdoc") version "0.2.0"
 }
 
 
@@ -67,6 +67,7 @@ dependencies {
     implementation 'com.github.spotbugs:spotbugs:3.1.12'
     implementation 'org.danilopianini:javalib-java7:0.6.1'
     implementation 'org.apache.commons:commons-math3:3.4'
+    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.50' // for Protelis2KotlinDoc
 }
 
 // set gradle version when generating the wrapper
@@ -93,15 +94,15 @@ test {
     ignoreFailures Boolean.getBoolean("test.ignoreFailures")        
 }
 
-//Protelis2KotlinDoc {
-//    baseDir.set("src/main/resources/protelis") // base dir from which recursively looking for .pt files
-//    // destDir.set("${project.buildDir.path}/protelis-docs/") // output dir for docs
-//    // kotlinVersion.set("+")
-//    // protelisVersion.set("+")
-//    outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
-//    debug.set(true) // Debug prints are disabled by default
-//    automaticDependencies.set(true)
-//}
+Protelis2KotlinDoc {
+    baseDir.set("src/main/resources/protelis") // base dir from which recursively looking for .pt files
+    // destDir.set("${project.buildDir.path}/protelis-docs/") // output dir for docs
+    // kotlinVersion.set("+")
+    // protelisVersion.set("+")
+    outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
+    debug.set(true) // Debug prints are disabled by default
+    automaticDependencies.set(false)
+}
 
 findbugs {
     ignoreFailures = true

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'maven-publish'
     id 'checkstyle'
     id 'findbugs'
-    id("org.protelis.protelisdoc") version "0.2.0"
+    //id("org.protelis.protelisdoc") version "0.2.0"
 }
 
 
@@ -39,31 +39,34 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.cedarsoftware', name: 'json-io', version:'4.9.12'
-    compile group: 'com.google.guava', name: 'guava', version:'22.0'
-    compile(group: 'org.protelis', name: 'protelis', version:'10.6.0') {
-exclude(module: 'guava')
-    }
-    compile group: 'commons-cli', name: 'commons-cli', version:'1.4'
-    compile group: 'net.sf.jung', name: 'jung-graph-impl', version:'2.0.1'
-    compile group: 'net.sf.jung', name: 'jung-algorithms', version:'2.0.1'
-    compile group: 'net.sf.jung', name: 'jung-visualization', version:'2.0.1'
-    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.25'
-    compile group: 'org.kie', name: 'kie-api', version:'7.0.0.Final'
+    implementation group: 'com.cedarsoftware', name: 'json-io', version:'4.9.12'
+    implementation group: 'com.google.guava', name: 'guava', version:'22.0'
+    implementation(group: 'org.protelis', name: 'protelis', version:'10.6.0')
+    implementation group: 'commons-cli', name: 'commons-cli', version:'1.4'
+    implementation group: 'net.sf.jung', name: 'jung-graph-impl', version:'2.0.1'
+    implementation group: 'net.sf.jung', name: 'jung-algorithms', version:'2.0.1'
+    implementation group: 'net.sf.jung', name: 'jung-visualization', version:'2.0.1'
+    implementation group: 'org.slf4j', name: 'slf4j-api', version:'1.7.25'
+    implementation group: 'org.kie', name: 'kie-api', version:'7.0.0.Final'
     runtime group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version:'2.8.2'
     runtime group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.8.2'
-    testCompile( group: 'junit', name: 'junit', version: '4.12') {
+    testImplementation( group: 'junit', name: 'junit', version: '4.12') {
         exclude module: 'hamcrest-core'
     }
-    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
     
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.8.9'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava', version:'2.8.9'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version:'2.8.9'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version:'2.8.9'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.9'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version:'2.8.9'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-guava', version:'2.8.9'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version:'2.8.9'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version:'2.8.9'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.9'
     
-    compile group: 'dnsjava', name: 'dnsjava', version: '2.1.8'      
+    implementation group: 'dnsjava', name: 'dnsjava', version: '2.1.8'
+
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.0'
+    implementation 'com.github.spotbugs:spotbugs:3.1.12'
+    implementation 'org.danilopianini:javalib-java7:0.6.1'
+    implementation 'org.apache.commons:commons-math3:3.4'
 }
 
 // set gradle version when generating the wrapper
@@ -90,15 +93,15 @@ test {
     ignoreFailures Boolean.getBoolean("test.ignoreFailures")        
 }
 
-Protelis2KotlinDoc {
-    baseDir.set("src/main/resources/protelis") // base dir from which recursively looking for .pt files
-    // destDir.set("${project.buildDir.path}/protelis-docs/") // output dir for docs
-    // kotlinVersion.set("+")
-    // protelisVersion.set("+")
-    outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
-    debug.set(true) // Debug prints are disabled by default
-    automaticDependencies.set(true)
-}
+//Protelis2KotlinDoc {
+//    baseDir.set("src/main/resources/protelis") // base dir from which recursively looking for .pt files
+//    // destDir.set("${project.buildDir.path}/protelis-docs/") // output dir for docs
+//    // kotlinVersion.set("+")
+//    // protelisVersion.set("+")
+//    outputFormat.set("javadoc") // Dokka's output format (alternative: 'html')
+//    debug.set(true) // Debug prints are disabled by default
+//    automaticDependencies.set(true)
+//}
 
 findbugs {
     ignoreFailures = true


### PR DESCRIPTION
@jakebeal 

I've fixed the build. I report a few notes that may be useful, historically.

- The problem was due to the upgrade of Gradle
- Dependencies must be adjusted from `compile` to `implementation` (or `api`)
- NOTE: related to this point, @jakebeal, it is fundamental to decide which dependencies are only part of the implementation and which dependencies belong to the API (i.e., they are to be exposed) [(see here for details)](https://docs.gradle.org/current/userguide/java_library_plugin.html); **this does affect projects that use this project**.
- After that, more dependencies had to be included in the build because the previous `compile` configuration was more inclusive in terms of transitive dependencies.
- The other problem was related to the plugin, which enforced a newer version of the Protelis dependency; this has been fixed by configuring the protelis2kdoc plugin to use the specific version of Protelis which is used in the project. 